### PR TITLE
Fix Windows extension-path crash (#2) + add Linux/Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,10 @@ jobs:
         run: bun run build
 
       - name: Test
+        # Skip the live-model smoke tests: they require a running pi model
+        # endpoint, which CI has no access to. `pi` is on PATH here (installed
+        # as a dependency), so the tests' own `which pi` guard doesn't catch
+        # this — PI_SKIP_SMOKE is the documented escape hatch.
         run: bun run test
+        env:
+          PI_SKIP_SMOKE: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: build & test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Don't cancel the Linux job when Windows fails (or vice versa) — we want
+      # to see both results. Windows is the reason this matrix exists: two
+      # separate Windows-only path bugs shipped because CI never ran there.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build (tsc)
+        run: bun run build
+
+      - name: Test
+        run: bun run test

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@types/turndown": "5.0.6",
         "@types/web-push": "3.6.4",
         "@types/ws": "8.18.1",
+        "cross-env": "^10.1.0",
         "eslint": "10.2.1",
         "globals": "17.5.0",
         "prettier": "3.8.3",
@@ -99,6 +100,8 @@
     "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.2", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.2", "@earendil-works/pi-ai": "^0.80.2", "@earendil-works/pi-tui": "^0.80.2", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-m9v7OUit0s9LklWfh61ca/XY5INjUzjtYtNZwy3cNvyjOLk3IpBgghP8aAp0iH35rLaiRwuuWiJ8t88ODMWY+A=="],
 
     "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.2", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-OvOAMIbXiC9OSse17YMiXIsI9AS5XM/ZV8N/k+UzdlRpPILDQYmLElevgGW92kkXR8qHBClIdzhCjuzlBGvphA=="],
+
+    "@epic-web/invariant": ["@epic-web/invariant@1.0.0", "", {}, "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 
@@ -285,6 +288,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "cross-env": ["cross-env@10.1.0", "", { "dependencies": { "@epic-web/invariant": "^1.0.0", "cross-spawn": "^7.0.6" }, "bin": { "cross-env": "dist/bin/cross-env.js", "cross-env-shell": "dist/bin/cross-env-shell.js" } }, "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scripts": {
         "build": "tsc -p tsconfig.build.json",
         "lint": "prettier --log-level warn --write 'src/**/*.ts' && eslint --fix . && tsc --noEmit",
-        "test": "cross-env AGENT=1 bun test src/",
+        "test": "cross-env AGENT=1 bun test --isolate src/",
         "prepublishOnly": "bun run build"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scripts": {
         "build": "tsc -p tsconfig.build.json",
         "lint": "prettier --log-level warn --write 'src/**/*.ts' && eslint --fix . && tsc --noEmit",
-        "test": "AGENT=1 bun test src/",
+        "test": "cross-env AGENT=1 bun test src/",
         "prepublishOnly": "bun run build"
     },
     "peerDependencies": {
@@ -42,6 +42,7 @@
         "@types/turndown": "5.0.6",
         "@types/web-push": "3.6.4",
         "@types/ws": "8.18.1",
+        "cross-env": "^10.1.0",
         "eslint": "10.2.1",
         "globals": "17.5.0",
         "prettier": "3.8.3",

--- a/src/shared/import-meta-path.test.ts
+++ b/src/shared/import-meta-path.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, test} from 'bun:test'
+import {readFileSync, readdirSync} from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+/**
+ * Windows regression guard (GitHub issue #2).
+ *
+ * `new URL('../x.js', import.meta.url).pathname` returns `/C:/Users/...` on
+ * Windows — a leading-slash + drive-letter string that pi then resolves against
+ * the current drive, yielding `C:\C:\Users\...` and a "Failed to load extension"
+ * crash in the second phase. `.pathname` also URL-decodes, so a path containing
+ * a space breaks on POSIX too. The correct conversion is `fileURLToPath()`.
+ *
+ * This test scans the whole source tree for the broken idiom so the fix can't
+ * silently regress. It is a cross-platform stand-in for actually running on
+ * Windows: it catches the specific bug class without a Windows runner.
+ */
+
+const SRC_DIR = fileURLToPath(new URL('..', import.meta.url))
+
+function walk(dir: string): string[] {
+    const out: string[] = []
+    for (const entry of readdirSync(dir, {withFileTypes: true})) {
+        const full = path.join(dir, entry.name)
+        if (entry.isDirectory()) {
+            if (entry.name === 'node_modules') continue
+            out.push(...walk(full))
+        } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+            out.push(full)
+        }
+    }
+    return out
+}
+
+describe('import.meta.url path resolution (Windows guard)', () => {
+    // Matches `new URL(..., import.meta.url) ... .pathname`, tolerating a newline
+    // before `.pathname` (prettier wraps long lines).
+    const BROKEN = /new URL\([^)]*import\.meta\.url[^)]*\)\s*\.pathname/
+
+    test('no source file resolves an import.meta.url URL via .pathname', () => {
+        const offenders = walk(SRC_DIR).filter(f => BROKEN.test(readFileSync(f, 'utf8')))
+        expect(offenders).toEqual([])
+    })
+})

--- a/src/task/enforce-guidelines.test.ts
+++ b/src/task/enforce-guidelines.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from 'bun:test'
 import {EventEmitter} from 'node:events'
+import {basename} from 'node:path'
 import {
     captureCommitDiff,
     discoverGuidelines,
@@ -21,7 +22,9 @@ import {USER_CANCELLED} from './child-runner.js'
 
 function fakeReader(files: Record<string, string>) {
     return async (p: string): Promise<string> => {
-        const name = p.split('/').pop()!
+        // discoverGuidelines builds the path with path.join → native separators
+        // on Windows; basename handles both '/' and '\'.
+        const name = basename(p)
         if (name in files) return files[name]
         throw new Error('ENOENT')
     }

--- a/src/task/final-gate.test.ts
+++ b/src/task/final-gate.test.ts
@@ -18,6 +18,17 @@ import {
 } from './final-gate.js'
 import {readAcceptDebts, recordAcceptDebt} from './accept-debt.js'
 
+// Some cases exercise irreducibly-POSIX process/shell mechanics — death by a
+// Unix signal (no equivalent on Windows), or shadowing `npm` (a .cmd on Windows,
+// which node's bare spawn can't resolve without a shell). Skip those on Windows
+// rather than pretend; the product paths they cover degrade to env-gap-skip there.
+const IS_WINDOWS = process.platform === 'win32'
+const itPosix = IS_WINDOWS ? test.skip : test
+
+/** A cross-platform child fixture: `node -e <script>` behaves identically on every
+ *  OS, unlike `sh -c` (no sh/POSIX-shell semantics on Windows). */
+const nodeScript = (script: string): [string, string[]] => [process.execPath, ['-e', script]]
+
 function makeDir(pkg?: object): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-final-gate-'))
     if (pkg) fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg, null, 2))
@@ -142,7 +153,9 @@ describe('runFinalIntegrationGate', () => {
     })
 
     test('command-not-found inside the script chain (127) is an env gap → skipped', async () => {
-        const dir = makeDir({scripts: {test: 'definitely-not-a-real-command-xyz'}})
+        // A command that exits 127 (command-not-found) is the env-gap contract;
+        // exit 127 explicitly so the case is deterministic on every OS's shell.
+        const dir = makeDir({scripts: {test: "node -e 'process.exit(127)'"}})
         const out = await runFinalIntegrationGate(dir)
         expect(out.ok).toBe(true)
     })
@@ -155,7 +168,7 @@ describe('runFinalIntegrationGate', () => {
         expect(out.reason).not.toContain('SHOULD-NOT-RUN')
     })
 
-    test('a lockfile desync FAILS the gate before any integration command runs', async () => {
+    itPosix('a lockfile desync FAILS the gate before any integration command runs', async () => {
         const dir = makeDir({scripts: {test: 'echo SHOULD-NOT-RUN && exit 1'}})
         fs.writeFileSync(path.join(dir, 'package-lock.json'), '{}')
         await withFakeBin(
@@ -171,7 +184,7 @@ describe('runFinalIntegrationGate', () => {
         )
     })
 
-    test('an in-sync lockfile passes and the check is named in the reason', async () => {
+    itPosix('an in-sync lockfile passes and the check is named in the reason', async () => {
         const dir = makeDir({scripts: {test: 'exit 0'}})
         fs.writeFileSync(path.join(dir, 'package-lock.json'), '{}')
         await withFakeBin('npm', 'exit 0', async () => {
@@ -182,7 +195,7 @@ describe('runFinalIntegrationGate', () => {
         })
     })
 
-    test('a lock-check tool that cannot run (127) is an env gap → skipped', async () => {
+    itPosix('a lock-check tool that cannot run (127) is an env gap → skipped', async () => {
         const dir = makeDir({scripts: {test: 'exit 0'}})
         fs.writeFileSync(path.join(dir, 'package-lock.json'), '{}')
         await withFakeBin('npm', 'exit 127', async () => {
@@ -191,7 +204,7 @@ describe('runFinalIntegrationGate', () => {
         })
     })
 
-    test('a lockfile check alone (no test/build scripts) still gates', async () => {
+    itPosix('a lockfile check alone (no test/build scripts) still gates', async () => {
         const dir = makeDir({name: 'x'})
         fs.writeFileSync(path.join(dir, 'package-lock.json'), '{}')
         await withFakeBin('npm', 'exit 1', async () => {
@@ -201,7 +214,10 @@ describe('runFinalIntegrationGate', () => {
 
     test('a crashing start command FAILS the gate after tests passed', async () => {
         const dir = makeDir({
-            scripts: {test: 'exit 0', start: 'echo "port 3000 in use" >&2 && exit 3'}
+            scripts: {
+                test: 'exit 0',
+                start: 'node -e \'process.stderr.write("port 3000 in use"); process.exit(3)\''
+            }
         })
         const out = await runFinalIntegrationGate(dir)
         expect(out.ok).toBe(false)
@@ -242,27 +258,35 @@ describe('discoverBootCommand', () => {
 
 describe('runBootCheck', () => {
     test('fast non-zero exit → FAIL carrying the output tail', async () => {
-        const r = await runBootCheck('/tmp', ['sh', ['-c', 'echo boom >&2; exit 3']])
+        const r = await runBootCheck(
+            os.tmpdir(),
+            nodeScript("process.stderr.write('boom'); process.exit(3)")
+        )
         expect(r).toEqual({outcome: 'fail', detail: 'exited 3 — boom'})
     })
 
     test('quick exit 0 → PASS (CLI-style run that finished)', async () => {
-        const r = await runBootCheck('/tmp', ['sh', ['-c', 'exit 0']])
+        const r = await runBootCheck(os.tmpdir(), nodeScript('process.exit(0)'))
         expect(r.outcome).toBe('pass')
     })
 
     test('still alive after the grace window → PASS, whole process group killed', async () => {
         const dir = makeDir()
         const pidFile = path.join(dir, 'child.pid')
-        const r = await runBootCheck(
-            dir,
-            ['sh', ['-c', `sleep 30 & echo $! > ${pidFile}; wait`]],
-            300
-        )
+        // A parent that spawns a long-lived grandchild, records its pid, and stays
+        // alive itself. The boot check must tear down the WHOLE tree (grandchild
+        // included), so a leaked server can't mask later boot checks — killGroup
+        // uses a process-group kill on POSIX and taskkill /T on Windows.
+        const fixture =
+            `const {spawn}=require('child_process');const fs=require('fs');`
+            + `const c=spawn(process.execPath,['-e','setTimeout(()=>{},600000)'],{stdio:'ignore'});`
+            + `fs.writeFileSync(${JSON.stringify(pidFile)},String(c.pid));`
+            + `setTimeout(()=>{},600000)`
+        const r = await runBootCheck(dir, nodeScript(fixture), 300)
         expect(r.outcome).toBe('pass')
         const pid = Number(fs.readFileSync(pidFile, 'utf8').trim())
-        // The grandchild (sleep) must die with the group, not linger and mask
-        // later boot checks. Poll briefly — SIGTERM delivery is asynchronous.
+        // The grandchild must die with the tree, not linger. Poll briefly — kill
+        // delivery is asynchronous.
         let alive = true
         for (let i = 0; i < 40 && alive; i++) {
             await new Promise(res => setTimeout(res, 50))
@@ -275,19 +299,21 @@ describe('runBootCheck', () => {
         expect(alive).toBe(false)
     })
 
-    test('signal death within the window → FAIL naming the signal', async () => {
-        const r = await runBootCheck('/tmp', ['sh', ['-c', 'kill -SEGV $$']])
+    // Death by a Unix signal has no Windows equivalent (child.on('exit') never
+    // reports a signal there), so this behavior is POSIX-only.
+    itPosix('signal death within the window → FAIL naming the signal', async () => {
+        const r = await runBootCheck(os.tmpdir(), ['sh', ['-c', 'kill -SEGV $$']])
         expect(r.outcome).toBe('fail')
         expect((r as {detail: string}).detail).toContain('SIGSEGV')
     })
 
     test('missing binary (ENOENT) is an env gap → skip', async () => {
-        const r = await runBootCheck('/tmp', ['definitely-not-a-real-command-xyz', []])
+        const r = await runBootCheck(os.tmpdir(), ['definitely-not-a-real-command-xyz', []])
         expect(r.outcome).toBe('skip')
     })
 
     test('exit 127 inside the script chain is an env gap → skip', async () => {
-        const r = await runBootCheck('/tmp', ['sh', ['-c', 'exit 127']])
+        const r = await runBootCheck(os.tmpdir(), nodeScript('process.exit(127)'))
         expect(r.outcome).toBe('skip')
     })
 })

--- a/src/task/final-gate.ts
+++ b/src/task/final-gate.ts
@@ -235,7 +235,16 @@ export function runBootCheck(
         }
         const killGroup = (sig: NodeJS.Signals) => {
             try {
-                if (child.pid) process.kill(-child.pid, sig)
+                if (!child.pid) return
+                if (process.platform === 'win32') {
+                    // Windows has no process groups / negative-pid kill. taskkill
+                    // /T tears down the whole tree (the detached child plus any
+                    // grandchildren it spawned); /F forces it, so the SIGTERM→
+                    // SIGKILL escalation collapses to one idempotent call.
+                    spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'])
+                } else {
+                    process.kill(-child.pid, sig)
+                }
             } catch {
                 // group already gone
             }

--- a/src/task/frozen-path-guard.test.ts
+++ b/src/task/frozen-path-guard.test.ts
@@ -141,6 +141,10 @@ function realGit(cwd: string): FrozenGit {
 function makeRepo(): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-frozen-test-'))
     gitCli(dir, 'init', '-q', '-b', 'main')
+    // Pin line endings so LF fixtures round-trip byte-for-byte through git on
+    // Windows CI (which defaults to core.autocrlf=true). Repo-level so the
+    // product's revert git calls honor it too.
+    gitCli(dir, 'config', 'core.autocrlf', 'false')
     fs.writeFileSync(path.join(dir, 'schema.ts'), 'export const price = positive\n')
     fs.mkdirSync(path.join(dir, 'src'))
     fs.writeFileSync(path.join(dir, 'src', 'server.ts'), 'export const boot = 1\n')

--- a/src/task/git-state-guard.test.ts
+++ b/src/task/git-state-guard.test.ts
@@ -23,6 +23,11 @@ function git(cwd: string, ...args: string[]): string {
 function makeRepo(): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-guard-test-'))
     git(dir, 'init', '-q', '-b', 'main')
+    // Pin line endings so content round-trips byte-for-byte through git on
+    // Windows (the CI runner defaults to core.autocrlf=true, which would rewrite
+    // the LF fixtures to CRLF on checkout). Repo-level so the product's own git
+    // calls during reconcile honor it too, not just this file's git() helper.
+    git(dir, 'config', 'core.autocrlf', 'false')
     fs.writeFileSync(path.join(dir, 'committed.txt'), 'committed v1\n')
     fs.writeFileSync(path.join(dir, 'src.ts'), 'export const a = 1\n')
     git(dir, 'add', '-A')

--- a/src/task/phases.ts
+++ b/src/task/phases.ts
@@ -3,6 +3,7 @@
  * critique) plus the config table that drives the orchestrator loop.
  */
 
+import {fileURLToPath} from 'node:url'
 import type {ExtensionCommandContext} from '@earendil-works/pi-coding-agent'
 import {docsFocused} from '../workers/docs-core.js'
 import {fetchFocused} from '../workers/fetch-core.js'
@@ -265,14 +266,16 @@ export interface PhaseResearchDeps extends ExternalContextDeps {
     getFileInventory?: (cwd: string, signal?: AbortSignal) => Promise<string>
 }
 
-const DOCS_EXTENSION_PATH = new URL('../workers/docs-extension.js', import.meta.url).pathname
+const DOCS_EXTENSION_PATH = fileURLToPath(new URL('../workers/docs-extension.js', import.meta.url))
 
 /** pi-worker-search + pi-worker-fetch, loaded into the APIS research worker only
  *  when a Brave key is configured (the tool without a key just errors, and a weak
  *  model burns calls on it). Search being absent from the research toolset was
  *  STRUCTURAL: three consecutive audited runs made 0 search calls because the
  *  child literally did not have the tool. */
-const SEARCH_EXTENSION_PATH = new URL('../workers/search-extension.js', import.meta.url).pathname
+const SEARCH_EXTENSION_PATH = fileURLToPath(
+    new URL('../workers/search-extension.js', import.meta.url)
+)
 
 /**
  * Is live web search configured for this process? The keyless providers (exa,
@@ -304,8 +307,9 @@ export const RESEARCH_SEARCH_HINT =
  * healthy recorded run, so neither rule has a legitimate false positive here.
  * See single-read-guard.ts.
  */
-const SINGLE_READ_EXTENSION_PATH = new URL('../workers/single-read-extension.js', import.meta.url)
-    .pathname
+const SINGLE_READ_EXTENSION_PATH = fileURLToPath(
+    new URL('../workers/single-read-extension.js', import.meta.url)
+)
 
 /**
  * Task-file heading under which a research worker's validated output is cached.

--- a/src/workers/docs-cache.test.ts
+++ b/src/workers/docs-cache.test.ts
@@ -65,6 +65,8 @@ test('delete from chunks fires the FTS5 delete trigger', () => {
 })
 
 test('defaultCachePath() ends with pi-worker/docs.sqlite', () => {
-    const p = defaultCachePath()
+    // defaultCachePath is a real filesystem path (native separators on Windows);
+    // normalize before the POSIX-style suffix check.
+    const p = defaultCachePath().replace(/\\/g, '/')
     expect(p.endsWith('/pi-worker/docs.sqlite')).toBe(true)
 })

--- a/src/workers/docs-index.test.ts
+++ b/src/workers/docs-index.test.ts
@@ -1,5 +1,6 @@
 import {test, expect} from 'bun:test'
 import * as fs from 'node:fs'
+import * as os from 'node:os'
 import * as path from 'node:path'
 import {openCache} from './docs-cache.js'
 import {ensureIndexed} from './docs-index.js'
@@ -50,7 +51,7 @@ test('ensureIndexed is idempotent on second call (cache hit)', () => {
 
 test('ensureIndexed re-ingests when content hash changes', () => {
     const cache = openCache(':memory:')
-    const tmpPkgRoot = fs.mkdtempSync('/tmp/docs-index-test-')
+    const tmpPkgRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-index-test-'))
     try {
         fs.writeFileSync(
             path.join(tmpPkgRoot, 'package.json'),

--- a/src/workers/docs-index.ts
+++ b/src/workers/docs-index.ts
@@ -165,7 +165,10 @@ function ingestBody(cache: CacheHandle, pkg: ResolvedPackage, contentHash: strin
         'INSERT INTO chunks (name, version, file_path, kind, content) VALUES (?, ?, ?, ?, ?)'
     )
     for (const abs of files.dts) {
-        const rel = path.relative(pkg.root, abs)
+        // Store the file identifier POSIX-style so indexed docs are identical
+        // across platforms (this value is a model-facing label, never re-joined
+        // to the filesystem — node reads forward slashes fine on Windows too).
+        const rel = path.relative(pkg.root, abs).replace(/\\/g, '/')
         let raw: string
         try {
             raw = fs.readFileSync(abs, 'utf8')
@@ -181,7 +184,7 @@ function ingestBody(cache: CacheHandle, pkg: ResolvedPackage, contentHash: strin
         }
     }
     if (files.readme) {
-        const rel = path.relative(pkg.root, files.readme)
+        const rel = path.relative(pkg.root, files.readme).replace(/\\/g, '/')
         const raw = fs.readFileSync(files.readme, 'utf8')
         const chunks = chunkReadme(raw)
         if (chunks.length) {

--- a/src/workers/docs-resolve.test.ts
+++ b/src/workers/docs-resolve.test.ts
@@ -12,20 +12,24 @@ import {
 
 const FIXTURES = path.resolve(__dirname, '__fixtures__')
 
+// resolvePackage returns native filesystem paths (backslashes on Windows). These
+// suffix assertions are written POSIX-style, so normalize separators first.
+const norm = (s: string | null | undefined): string => (s ?? '').replace(/\\/g, '/')
+
 test('resolvePackage returns name, version, root, entryDts, readme for tiny-pkg', () => {
     const r = resolvePackage('tiny-pkg', FIXTURES)
     expect(r.name).toBe('tiny-pkg')
     expect(r.version).toBe('1.0.0')
-    expect(r.root.endsWith('node_modules/tiny-pkg')).toBe(true)
-    expect(r.entryDts?.endsWith('node_modules/tiny-pkg/index.d.ts')).toBe(true)
-    expect(r.readme?.endsWith('node_modules/tiny-pkg/README.md')).toBe(true)
+    expect(norm(r.root).endsWith('node_modules/tiny-pkg')).toBe(true)
+    expect(norm(r.entryDts).endsWith('node_modules/tiny-pkg/index.d.ts')).toBe(true)
+    expect(norm(r.readme).endsWith('node_modules/tiny-pkg/README.md')).toBe(true)
 })
 
 test('resolvePackage handles scoped packages', () => {
     const r = resolvePackage('@scope/scoped-pkg', FIXTURES)
     expect(r.name).toBe('@scope/scoped-pkg')
     expect(r.version).toBe('0.2.1')
-    expect(r.entryDts?.endsWith('node_modules/@scope/scoped-pkg/index.d.ts')).toBe(true)
+    expect(norm(r.entryDts).endsWith('node_modules/@scope/scoped-pkg/index.d.ts')).toBe(true)
     expect(r.readme).toBeNull()
 })
 
@@ -34,25 +38,25 @@ test('resolvePackage handles subpath but preserves parent name', () => {
     expect(r.name).toBe('tiny-pkg')
     expect(r.version).toBe('1.0.0')
     // entryDts should resolve to the subpath file
-    expect(r.entryDts?.endsWith('node_modules/tiny-pkg/sub.d.ts')).toBe(true)
+    expect(norm(r.entryDts).endsWith('node_modules/tiny-pkg/sub.d.ts')).toBe(true)
 })
 
 test('resolvePackage handles modern exports field', () => {
     const r = resolvePackage('modern-pkg', FIXTURES)
     expect(r.name).toBe('modern-pkg')
     expect(r.version).toBe('2.0.0')
-    expect(r.entryDts?.endsWith('node_modules/modern-pkg/dist/index.d.ts')).toBe(true)
+    expect(norm(r.entryDts).endsWith('node_modules/modern-pkg/dist/index.d.ts')).toBe(true)
 })
 
 test('resolvePackage falls back to <root>/index.d.ts when types field absent', () => {
     const r = resolvePackage('legacy-pkg', FIXTURES)
-    expect(r.entryDts?.endsWith('node_modules/legacy-pkg/index.d.ts')).toBe(true)
+    expect(norm(r.entryDts).endsWith('node_modules/legacy-pkg/index.d.ts')).toBe(true)
 })
 
 test('resolvePackage returns entryDts=null for package with no types', () => {
     const r = resolvePackage('no-types-pkg', FIXTURES)
     expect(r.entryDts).toBeNull()
-    expect(r.readme?.endsWith('node_modules/no-types-pkg/README.md')).toBe(true)
+    expect(norm(r.readme).endsWith('node_modules/no-types-pkg/README.md')).toBe(true)
 })
 
 test('resolvePackage returns both null for empty-pkg', () => {
@@ -104,7 +108,7 @@ test('typesPackageName maps to DefinitelyTyped convention', () => {
 
 test('resolvePackage picks a .d.mts types entry (tailwindcss shape)', () => {
     const r = resolvePackage('mts-pkg', FIXTURES)
-    expect(r.entryDts?.endsWith('node_modules/mts-pkg/dist/lib.d.mts')).toBe(true)
+    expect(norm(r.entryDts).endsWith('node_modules/mts-pkg/dist/lib.d.mts')).toBe(true)
 })
 
 test('hasTypeFiles is false for a launcher package with no declarations', () => {

--- a/src/workers/single-read-extension.test.ts
+++ b/src/workers/single-read-extension.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, test} from 'bun:test'
+import {resolve} from 'node:path'
 import singleReadExtension from './single-read-extension.js'
 
 type Handler = (event: {toolName: string; input: unknown}) => unknown
@@ -27,7 +28,8 @@ describe('single-read-extension', () => {
         expect(handler!(ev)).toBeUndefined()
         const blocked = handler!(ev) as {block?: boolean; reason?: string}
         expect(blocked.block).toBe(true)
-        expect(blocked.reason).toContain('/tmp/x.ts')
+        // The guard keys on the resolved absolute path (native separators on Windows).
+        expect(blocked.reason).toContain(resolve(process.cwd(), '/tmp/x.ts'))
     })
 
     test('allows the first grep, blocks an identical repeat', () => {


### PR DESCRIPTION
## Problem
GitHub issue #2 (2nd Windows report): pi-task crashes in the second phase on Windows with `Failed to load extension "C:\C:\Users\..."`.

**Root cause:** `src/task/phases.ts` built the paths for the extensions it loads into child workers with `new URL('../workers/x.js', import.meta.url).pathname`. On Windows `.pathname` returns `/C:/Users/...` (leading slash + drive letter); pi resolves that against the current drive → `C:\C:\Users\...`. (`.pathname` also URL-decodes, so paths with spaces break on POSIX too.)

## The #2 fix
- Resolve all three extension paths with `fileURLToPath()` (the idiom `html-clean.ts` already uses correctly).
- Regression test that fails if the `.pathname`-on-`import.meta.url` idiom returns anywhere in `src/`.

## CI (new) — Linux + Windows
There was no CI at all — which is why two separate Windows-only path bugs shipped. Added a GitHub Actions matrix (`ubuntu-latest` + `windows-latest`) running install / build / test. **Both green.**

Standing this CI up surfaced, and this PR fixes, a layer of pre-existing issues (all hidden locally because a llama-server runs there):

1. **Test isolation** — session-state's module singleton leaked `s.model` across test files (bun shares globals by default; `reset()` preserves model). Fixed with `bun test --isolate`; also cures a rare local flake.
2. **Live-model smoke tests** — `real-pi.smoke.test` needs a model endpoint; its `which pi` guard doesn't fire in CI (pi is on PATH as a dep). Set `PI_SKIP_SMOKE=1` in the CI step.
3. **28 Windows-specific failures**, by root cause:
   - Path-separator assertions hardcoding `/` → normalized (product stays native).
   - Docs index `file_path` → stored POSIX-style (model-facing label, cross-platform-consistent).
   - Hardcoded `/tmp` → `os.tmpdir()`.
   - CRLF: pin `core.autocrlf=false` in the throwaway git repos so LF fixtures round-trip on Windows CI.
   - Boot-check process kill: `process.kill(-pid)` is POSIX-only → added a `taskkill /T /F` branch (product fix).
   - final-gate fixtures: `sh -c`/`>&2`/bare-missing-command → cross-platform `node -e`. Signal-death and npm-shadow cases are irreducibly POSIX → skipped on Windows (those product paths degrade to env-gap-skip there).

**Result:** Ubuntu green; Windows 1399 pass / 8 skip / 0 fail (8 skips = 1 pre-existing + 2 live-model + 5 POSIX-only).

Closes #2.