### PR TITLE
fix(watchdog): a ref'd poll — the unref'd one is dead on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
         run: bun run test
         env:
           PI_SKIP_SMOKE: "1"
+          # Print `::test-file <path>` as each file starts (bunfig preload,
+          # inert without this var). Run 30472844957 hung with the log ending
+          # on orientation-replay.test.ts — but that is just the last file that
+          # console.logs; bun prints a file header only for files that write
+          # output, so the hung log named the wrong file. With this on, the
+          # last ::test-file line IS the file that hung.
+          PI_TEST_PROGRESS: "1"
 
       # ---------------------------------------------------------------------
       # Post-test diagnostics. These exist to characterise an intermittent hang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,22 @@ jobs:
       - name: Build (tsc)
         run: bun run build
 
+      # TEMPORARY: mechanism probe for the windows hang. The stall guard polls
+      # on an UNREF'd setInterval (stream-watchdog.ts realStreamTimerDeps). If an
+      # unref'd timer never fires on windows once nothing ref'd is pending, every
+      # test that waits for the guard hangs forever — which is what the per-test
+      # probe shows. This isolates that one behaviour from everything else.
+      - name: Probe unref'd timer
+        shell: bash
+        timeout-minutes: 3
+        run: |
+          echo "=== unref'd interval, nothing else pending"
+          timeout 20 bun -e 'const t0=Date.now(); const r=await new Promise(res=>{const h=setInterval(()=>res("fired"),100); h.unref?.()}); console.log(r, Date.now()-t0, "ms")' \
+            || echo "=== EXIT $? (no output above means it never fired)"
+          echo "=== ref'd interval, same shape"
+          timeout 20 bun -e 'const t0=Date.now(); const r=await new Promise(res=>{setInterval(()=>res("fired"),100)}); console.log(r, Date.now()-t0, "ms"); process.exit(0)' \
+            || echo "=== EXIT $?"
+
       # TEMPORARY (this branch only): run 30476786365 named the hung file —
       # src/task/stream-stall.test.ts, loaded at 17:47:42, silent until the
       # step timeout 9 min later. Run its tests ONE AT A TIME under a hard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,33 @@ jobs:
       - name: Build (tsc)
         run: bun run build
 
+      # TEMPORARY (this branch only): run 30476786365 named the hung file —
+      # src/task/stream-stall.test.ts, loaded at 17:47:42, silent until the
+      # step timeout 9 min later. Run its tests ONE AT A TIME under a hard
+      # per-test timeout so the log names the hung TEST. Delete before merge.
+      - name: Probe stream-stall (per test)
+        shell: bash
+        timeout-minutes: 8
+        env:
+          PI_SKIP_SMOKE: "1"
+        run: |
+          while IFS= read -r t; do
+            echo "=== $t"
+            timeout 60 bun test --isolate src/task/stream-stall.test.ts -t "$t" \
+              || echo "=== EXIT $? on: $t"
+          done <<'NAMES'
+          kills a child that streams events then goes silent
+          does NOT kill while a tool is executing
+          leaves the old behaviour
+          runWorker restarts a stream-stalled attempt
+          an attempt that keeps stalling surfaces streamStalled
+          a hung stream is retried and the retry succeeds
+          NAMES
+
       - name: Test
+        # TEMPORARY (this branch only): the full suite hangs 10 min on windows,
+        # and the probe above is what this run exists for. Restore before merge.
+        if: runner.os != 'Windows'
         # Skip the live-model smoke tests: they require a running pi model
         # endpoint, which CI has no access to. `pi` is on PATH here (installed
         # as a dependency), so the tests' own `which pi` guard doesn't catch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,49 +39,7 @@ jobs:
       - name: Build (tsc)
         run: bun run build
 
-      # TEMPORARY: mechanism probe for the windows hang. The stall guard polls
-      # on an UNREF'd setInterval (stream-watchdog.ts realStreamTimerDeps). If an
-      # unref'd timer never fires on windows once nothing ref'd is pending, every
-      # test that waits for the guard hangs forever — which is what the per-test
-      # probe shows. This isolates that one behaviour from everything else.
-      - name: Probe unref'd timer
-        shell: bash
-        timeout-minutes: 3
-        run: |
-          echo "=== unref'd interval, nothing else pending"
-          timeout 20 bun -e 'const t0=Date.now(); const r=await new Promise(res=>{const h=setInterval(()=>res("fired"),100); h.unref?.()}); console.log(r, Date.now()-t0, "ms")' \
-            || echo "=== EXIT $? (no output above means it never fired)"
-          echo "=== ref'd interval, same shape"
-          timeout 20 bun -e 'const t0=Date.now(); const r=await new Promise(res=>{setInterval(()=>res("fired"),100)}); console.log(r, Date.now()-t0, "ms"); process.exit(0)' \
-            || echo "=== EXIT $?"
-
-      # TEMPORARY (this branch only): run 30476786365 named the hung file —
-      # src/task/stream-stall.test.ts, loaded at 17:47:42, silent until the
-      # step timeout 9 min later. Run its tests ONE AT A TIME under a hard
-      # per-test timeout so the log names the hung TEST. Delete before merge.
-      - name: Probe stream-stall (per test)
-        shell: bash
-        timeout-minutes: 8
-        env:
-          PI_SKIP_SMOKE: "1"
-        run: |
-          while IFS= read -r t; do
-            echo "=== $t"
-            timeout 60 bun test --isolate src/task/stream-stall.test.ts -t "$t" \
-              || echo "=== EXIT $? on: $t"
-          done <<'NAMES'
-          kills a child that streams events then goes silent
-          does NOT kill while a tool is executing
-          leaves the old behaviour
-          runWorker restarts a stream-stalled attempt
-          an attempt that keeps stalling surfaces streamStalled
-          a hung stream is retried and the retry succeeds
-          NAMES
-
       - name: Test
-        # TEMPORARY (this branch only): the full suite hangs 10 min on windows,
-        # and the probe above is what this run exists for. Restore before merge.
-        if: runner.os != 'Windows'
         # Skip the live-model smoke tests: they require a running pi model
         # endpoint, which CI has no access to. `pi` is on PATH here (installed
         # as a dependency), so the tests' own `which pi` guard doesn't catch

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,2 +1,5 @@
 [test]
 pathIgnorePatterns = ["dist/**", "**/__fixtures__/**"]
+# Names each test file as it starts, so a hung CI log says WHICH file hung.
+# Inert unless PI_TEST_PROGRESS is set (CI sets it) — see the script's header.
+preload = ["./scripts/test-file-progress.ts"]

--- a/scripts/test-file-progress.ts
+++ b/scripts/test-file-progress.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-file progress for `bun test`, as a preload plugin.
+ *
+ * WHY: the CI Test step hangs at random (see the workflow's Test step comment).
+ * The 10-min step timeout preserves the log, but the log could not say WHICH
+ * file was running: `bun test` prints a file header only for files that write
+ * output of their own, so the last header in a hung log names the last file
+ * that happened to console.log — not the file that hung. Run 30472844957's log
+ * ended on `orientation-replay.test.ts` purely because that file prints a line.
+ *
+ * An onLoad plugin fires as each test file is loaded, and loading is lazy —
+ * verified interleaved with test output, not batched up front — so the LAST
+ * `::test-file` line in a hung log is the file that hung.
+ *
+ * OFF unless PI_TEST_PROGRESS is set (CI sets it): 154 extra lines would drown
+ * a local run, and the plugin then costs nothing at all.
+ */
+import {plugin} from 'bun'
+import path from 'node:path'
+
+if (process.env.PI_TEST_PROGRESS) {
+    const root = process.cwd()
+    plugin({
+        name: 'test-file-progress',
+        setup(build) {
+            build.onLoad({filter: /\.test\.tsx?$/}, async args => {
+                // Relative keeps the line short and identical across runners.
+                process.stdout.write(`::test-file ${path.relative(root, args.path)}\n`)
+                // Hand the source back unchanged; bun transpiles it as usual.
+                return {contents: await Bun.file(args.path).text(), loader: 'ts'}
+            })
+        }
+    })
+}

--- a/src/shared/command-watchdog.ts
+++ b/src/shared/command-watchdog.ts
@@ -179,17 +179,17 @@ export class CommandWatchdog {
 }
 
 /**
- * Real-clock schedule/cancel, unref'd so a pending watchdog timer can never
- * itself keep the process alive on exit. Shared by both adapters; tests
- * substitute a fake scheduler instead.
+ * Real-clock schedule/cancel. Shared by both adapters; tests substitute a fake
+ * scheduler instead.
+ *
+ * REF'd, for the same measured reason as the stream watchdog's poll (see
+ * realStreamTimerDeps): under Bun on windows an unref'd timer never fires once
+ * nothing ref'd is pending, and a child sitting in a hung command is exactly
+ * that state — so the unref disabled the guard in the one case it exists for.
+ * The timer is cleared when the tool ends and in runWorker's `finally`, so it
+ * cannot outlive the call it watches.
  */
 export const realTimerDeps: Pick<WatchdogDeps, 'schedule' | 'cancel'> = {
-    schedule: (fn, ms) => {
-        const handle = setTimeout(fn, ms)
-        if (typeof (handle as {unref?: () => void}).unref === 'function') {
-            ;(handle as {unref: () => void}).unref()
-        }
-        return handle
-    },
+    schedule: (fn, ms) => setTimeout(fn, ms),
     cancel: handle => clearTimeout(handle as ReturnType<typeof setTimeout>)
 }

--- a/src/shared/stream-watchdog.test.ts
+++ b/src/shared/stream-watchdog.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, test} from 'bun:test'
 import {
     DEFAULT_STREAM_INACTIVITY_MS,
     pollIntervalMs,
+    realStreamTimerDeps,
     StreamWatchdog,
     streamStallCause,
     streamStallHint,
@@ -149,6 +150,24 @@ describe('StreamWatchdog', () => {
         h.wd.stop()
         h.advance(10_000)
         expect(h.fires).toEqual([])
+    })
+})
+
+describe('realStreamTimerDeps', () => {
+    // The poll must stay REF'd. Under Bun on windows an unref'd timer never fires
+    // once nothing ref'd is pending — and a child whose stream has gone silent is
+    // exactly that state, so an unref'd poll disabled the guard in the one case it
+    // exists for and hung every stream-stall test on windows for nine days
+    // (measured on a windows-latest runner: unref'd never fired in 20s, ref'd
+    // fired at 101ms; linux fires either way, which is why only CI caught it).
+    // Asserted on the handle rather than by waiting, so this fails on ANY platform.
+    test('schedules a REF’d poll — an unref’d one is dead on windows', () => {
+        const h = realStreamTimerDeps.schedule(() => {}, 60_000) as {hasRef?: () => boolean}
+        try {
+            expect(h.hasRef?.()).toBe(true)
+        } finally {
+            realStreamTimerDeps.cancel(h as TimerHandle)
+        }
     })
 })
 

--- a/src/shared/stream-watchdog.ts
+++ b/src/shared/stream-watchdog.ts
@@ -164,19 +164,27 @@ export class StreamWatchdog {
 }
 
 /**
- * Real-clock poll deps, unref'd so a pending watchdog poll can never itself keep
- * the process alive on exit. `schedule` returns a repeating interval — the
- * machine cancels it on stop/fire.
+ * Real-clock poll deps. `schedule` returns a repeating interval — the machine
+ * cancels it on stop/fire, and runChild's cleanup() stops the watchdog on every
+ * settle path (close, error, abort), so it cannot outlive the child it watches.
+ *
+ * The poll is REF'd, deliberately. It used to be unref'd, on the reasoning that a
+ * pending watchdog poll should never keep the process alive at exit — but under
+ * Bun on WINDOWS an unref'd timer does not fire at all once nothing ref'd is
+ * pending. Measured on a windows-latest runner (bun 1.3.14): an unref'd interval
+ * with nothing else pending never fired in 20s, while the identical ref'd one
+ * fired at 101ms; on linux both fire at 100ms.
+ *
+ * That state — no ref'd work outstanding — is EXACTLY the state this watchdog
+ * exists to police: a child whose model stream has gone silent. So the unref
+ * disabled the guard precisely when it was needed, and every stream-stall
+ * integration test hung forever on windows (CI runs 30476786365, 30477802633,
+ * 30478455402 — it hangs at v0.24.1 too, so this predates that release).
+ * A poll that can delay exit by one interval is the cheaper failure.
  */
 export const realStreamTimerDeps: Pick<StreamWatchdogDeps, 'now' | 'schedule' | 'cancel'> = {
     now: () => Date.now(),
-    schedule: (fn, ms) => {
-        const handle = setInterval(fn, ms)
-        if (typeof (handle as {unref?: () => void}).unref === 'function') {
-            ;(handle as {unref: () => void}).unref()
-        }
-        return handle
-    },
+    schedule: (fn, ms) => setInterval(fn, ms),
     cancel: handle => clearInterval(handle as ReturnType<typeof setInterval>)
 }
 

--- a/src/task/command-watchdog.test.ts
+++ b/src/task/command-watchdog.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from 'bun:test'
 import {CommandWatchdog, reminderMessage, type WatchdogDeps} from './command-watchdog.js'
+import {realTimerDeps} from '../shared/command-watchdog.js'
 
 /**
  * A synchronous fake scheduler: records armed timers and lets the test fire one
@@ -136,5 +137,20 @@ describe('reminderMessage', () => {
 
     test('sub-minute ceilings round up to at least 1 minute (never "0 minutes")', () => {
         expect(reminderMessage('bash', 30_000)).toContain('1 minute')
+    })
+})
+
+describe('realTimerDeps', () => {
+    // Same measured windows failure as the stream watchdog's poll: under Bun an
+    // unref'd timer never fires once nothing ref'd is pending, and a child sitting
+    // in a hung command IS that state — so an unref'd ceiling silently disabled the
+    // guard on windows. Asserted on the handle, so it fails on any platform.
+    test('schedules a REF’d timer — an unref’d one is dead on windows', () => {
+        const h = realTimerDeps.schedule(() => {}, 60_000) as {hasRef?: () => boolean}
+        try {
+            expect(h.hasRef?.()).toBe(true)
+        } finally {
+            realTimerDeps.cancel(h as never)
+        }
     })
 })


### PR DESCRIPTION
Main's windows job hung for 10 minutes on v0.24.2 (run 30472844957) and hung identically on a rerun of the same tree, while ubuntu stayed green in ~60s.

**Root cause.** Both watchdogs scheduled their timers unref'd. Under Bun on windows an unref'd timer does not fire at all once nothing ref'd is pending — which is exactly the state each guard exists to police: a child whose model stream has gone silent, or one sitting in a hung command. Measured on a windows-latest runner (bun 1.3.14), two arms of one probe:

| timer | result |
| --- | --- |
| unref'd interval, nothing else pending | never fired, killed at 20s |
| ref'd interval, same shape | fired at 101ms |

Linux fires either way at 100ms — which is why every local run and every ubuntu job stayed green while the guard was dead on windows.

**How it was found.** The log could not name the hung file (bun prints a file header only for files that write output, so both hung logs ended on `orientation-replay.test.ts`, the last file that happens to console.log). The `::test-file` preload in the first commit named it: `src/task/stream-stall.test.ts`. A per-test probe there showed 5 of its 6 tests hanging 60s each — and the one that PASSES is the one where the guard is deliberately off (`streamInactivityMs: 0`). Every hanging test waits on a watchdog that can never fire.

**It predates v0.24.2.** The same probe run on v0.24.1 — the last green windows run — hangs identically. The suite was passing on luck: some other ref'd work happened to keep the loop alive.

**Verified:** windows job green in 2m52s, full suite 2517 tests / 154 files / 83s (it was hitting the 10-min timeout at ~53s in). Both real dep objects now carry a `hasRef()` regression test, which fails on linux too if the unref comes back.

Kept from the diagnosis: the `::test-file` progress preload (inert unless `PI_TEST_PROGRESS` is set, which only the CI Test step does). The temporary probe steps are reverted.