### PR TITLE
fix: allow durable tools to opt out of command timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,19 @@ Resolves an installed npm package, indexes its `.d.ts` files and README into a l
 
 Run `/task-config` to toggle pi-task's behavior in an editor dialog. Settings persist to `~/.config/pi-task/config.json`.
 
+Long-running extension tools that already implement their own bounded child
+timeouts and cancellation can be excluded from the generic per-tool command
+watchdog without disabling protection for `bash`:
+
+```json
+{
+  "commandTimeoutExemptTools": ["fable_loop"]
+}
+```
+
+Names are matched exactly. This does not disable the model-stream watchdog or
+any timeout implemented by the exempt tool itself.
+
 | Setting | Default | What it does |
 | --- | --- | --- |
 | **remote control** | on | The remote UI server (QR code, phone access). Turn off to never start it. |

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -3,10 +3,26 @@ import {
     COMMAND_TIMEOUT_OPTIONS,
     DEBUG_LOG_OPTIONS,
     sanitizeDebugLogs,
+    sanitizeCommandTimeoutExemptTools,
     sanitizeRequestTimeoutMs,
     sanitizeStreamInactivityMs,
     STREAM_INACTIVITY_OPTIONS
 } from './config.js'
+
+describe('sanitizeCommandTimeoutExemptTools', () => {
+    test('keeps unique non-empty tool names', () => {
+        expect(
+            sanitizeCommandTimeoutExemptTools(['fable_loop', ' fable_loop ', 'durable_job', '', 42])
+        ).toEqual(['fable_loop', 'durable_job'])
+    })
+
+    test('rejects non-arrays and entries that are not tool names', () => {
+        for (const bad of [undefined, null, 'fable_loop', {}, 1]) {
+            expect(sanitizeCommandTimeoutExemptTools(bad)).toEqual([])
+        }
+        expect(sanitizeCommandTimeoutExemptTools(['has spaces', 'slash/name', '-bad'])).toEqual([])
+    })
+})
 
 describe('COMMAND_TIMEOUT_OPTIONS', () => {
     test('offers 5/10/15/30 min plus off, with off stored as 0', () => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -68,6 +68,15 @@ export interface PiTaskConfig {
      */
     requestTimeoutMs: number
     /**
+     * Extension tools that own a stronger, domain-specific timeout and
+     * cancellation contract. The generic command watchdog must not abort these
+     * tools mid-transaction; bash and every other tool remain guarded.
+     *
+     * This is intentionally an advanced config-file setting rather than a
+     * blanket switch in /task-config. Tool names are matched exactly.
+     */
+    commandTimeoutExemptTools: string[]
+    /**
      * Inactivity ceiling (ms) on the MODEL STREAM before the stream watchdog
      * aborts the request (shared/stream-watchdog.ts). A hung or silently-dropped
      * stream throws nothing, so neither the connection-error retry (needs a
@@ -175,6 +184,21 @@ export function sanitizeRequestTimeoutMs(value: unknown): number {
         :   DEFAULT_REQUEST_TIMEOUT_MS
 }
 
+/** Keep only exact, unique Pi tool names from an advanced config override. */
+export function sanitizeCommandTimeoutExemptTools(value: unknown): string[] {
+    if (!Array.isArray(value)) return []
+    const result: string[] = []
+    const seen = new Set<string>()
+    for (const item of value) {
+        if (typeof item !== 'string') continue
+        const name = item.trim()
+        if (!/^[A-Za-z0-9_][A-Za-z0-9_.:-]*$/.test(name) || seen.has(name)) continue
+        seen.add(name)
+        result.push(name)
+    }
+    return result
+}
+
 /**
  * The stream-watchdog choices offered by /task-config, in cycle order. Every
  * option is minutes, not seconds: the failure this guards costs hours, and the
@@ -210,6 +234,7 @@ const DEFAULTS: PiTaskConfig = {
     searchProvider: 'exa',
     extensionWhitelist: [],
     requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
+    commandTimeoutExemptTools: [],
     streamInactivityMs: DEFAULT_STREAM_INACTIVITY_MS,
     // OFF: auto-answering is for unattended throwaway runs only.
     yoloMode: false,
@@ -247,6 +272,9 @@ if (!G.loaded) {
         if (!isSearchProvider(parsed.searchProvider)) delete parsed.searchProvider
         parsed.extensionWhitelist = sanitizeExtensionWhitelist(parsed.extensionWhitelist)
         parsed.requestTimeoutMs = sanitizeRequestTimeoutMs(parsed.requestTimeoutMs)
+        parsed.commandTimeoutExemptTools = sanitizeCommandTimeoutExemptTools(
+            parsed.commandTimeoutExemptTools
+        )
         parsed.streamInactivityMs = sanitizeStreamInactivityMs(parsed.streamInactivityMs)
         // A hand-edited `"yoloMode": "false"` is a truthy string — it must not
         // silently switch a watched run into unattended auto-pick. Only a real

--- a/src/shared/command-watchdog.ts
+++ b/src/shared/command-watchdog.ts
@@ -40,6 +40,8 @@ export interface WatchdogDeps {
      * 0 (or any non-positive value) means the watchdog is off and never arms.
      */
     getTimeoutMs: () => number
+    /** Optional exact policy for tools with their own bounded execution contract. */
+    shouldWatch?: (toolName: string) => boolean
     schedule: (fn: () => void, ms: number) => TimerHandle
     cancel: (handle: TimerHandle) => void
     /** Invoked when a command overruns: each adapter aborts/kills here. */
@@ -141,10 +143,12 @@ export class CommandWatchdog {
 
     /** Arm a timer for a starting tool. No-op when the watchdog is off. */
     onStart(toolCallId: string, toolName: string): void {
+        // Disarm first so a live policy/config change cannot leave a timer from
+        // a duplicate start armed after the tool becomes exempt or watchdog-off.
+        this.disarm(toolCallId)
+        if (this.deps.shouldWatch?.(toolName) === false) return
         const ms = this.deps.getTimeoutMs()
         if (!(ms > 0)) return
-        // A duplicate start for the same id must not leak the previous timer.
-        this.disarm(toolCallId)
         const handle = this.deps.schedule(() => this.fire(toolCallId, toolName, ms), ms)
         this.active.set(toolCallId, handle)
     }

--- a/src/task/command-watchdog.test.ts
+++ b/src/task/command-watchdog.test.ts
@@ -6,7 +6,7 @@ import {realTimerDeps} from '../shared/command-watchdog.js'
  * A synchronous fake scheduler: records armed timers and lets the test fire one
  * by id, so the state machine is exercised without real time passing.
  */
-function makeHarness(timeoutMs: number) {
+function makeHarness(timeoutMs: number, shouldWatch?: (toolName: string) => boolean) {
     let nextId = 0
     const timers = new Map<number, () => void>()
     const fired: {toolCallId: string; toolName: string; timeoutMs: number}[] = []
@@ -14,6 +14,7 @@ function makeHarness(timeoutMs: number) {
 
     const deps: WatchdogDeps = {
         getTimeoutMs: () => currentTimeout,
+        shouldWatch,
         schedule: fn => {
             const id = nextId++
             timers.set(id, fn)
@@ -61,6 +62,17 @@ describe('CommandWatchdog', () => {
         h.watchdog.onStart('call-1', 'bash')
         expect(h.armedCount()).toBe(0)
         expect(h.fired).toHaveLength(0)
+    })
+
+    test('an explicitly exempt tool never arms while other tools remain guarded', () => {
+        const h = makeHarness(900_000, toolName => toolName !== 'fable_loop')
+        h.watchdog.onStart('call-1', 'fable_loop')
+        expect(h.armedCount()).toBe(0)
+
+        h.watchdog.onStart('call-2', 'bash')
+        expect(h.armedCount()).toBe(1)
+        h.elapse(0)
+        expect(h.fired).toEqual([{toolCallId: 'call-2', toolName: 'bash', timeoutMs: 900_000}])
     })
 
     test('the ceiling is read per start, so a config change takes effect next command', () => {

--- a/src/task/command-watchdog.ts
+++ b/src/task/command-watchdog.ts
@@ -18,8 +18,9 @@ import {CommandWatchdog, realTimerDeps, reminderMessage} from '../shared/command
  * the whole process tree on abort — then a follow-up user turn tells the model
  * what happened so it retries with a timeout instead of hanging again.
  *
- * Tool-agnostic: it arms on ANY tool, honouring "any command can run forever",
- * though in practice only bash runs long enough to trip it.
+ * Tool-agnostic by default: it arms on every tool except exact names listed in
+ * `commandTimeoutExemptTools`. Exemptions are reserved for extension tools
+ * that already own a bounded timeout and cancellation contract.
  *
  * SCOPE — this covers the main session ONLY, which is where the implementation
  * turn runs (orchestrator hands the spec off via sendUserMessage). Gate
@@ -80,6 +81,7 @@ export function registerCommandWatchdog(pi: ExtensionAPI): void {
 
     const watchdog = new CommandWatchdog({
         getTimeoutMs: () => getConfig().requestTimeoutMs,
+        shouldWatch: toolName => !getConfig().commandTimeoutExemptTools.includes(toolName),
         ...realTimerDeps,
         onFire: (toolCallId, toolName, timeoutMs) => {
             const ctx = ctxByCall.get(toolCallId)


### PR DESCRIPTION
## Problem

The command watchdog currently arms for every tool. Durable orchestration tools can own longer child timeout and cancellation contracts, but are still aborted at the default 15-minute boundary.

This was reproduced with fable_loop: two jobs were cancelled at 15:00.5 despite healthy child progress and a 30-minute child timeout.

## Change

- add an exact-name commandTimeoutExemptTools advanced config option
- skip only configured tools in the generic command watchdog
- preserve the model-stream watchdog and every tool-owned timeout
- keep bash and all non-exempt tools guarded
- document the setting and sanitize hand-edited config

## Tests

- PI_SKIP_SMOKE=1 bun run test: 2671 passed, 0 failed, 6 skipped
- bun run build
- bunx tsc --noEmit
- bunx tsc -p scripts/tsconfig.json --noEmit
- bunx eslint .

The two optional real-Pi smoke tests were separately attempted but this checkout has no Anthropic credential/model mapping; they fail before exercising this change.